### PR TITLE
ci: stop the docs workflow from racing semantic-release

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,14 +1,22 @@
 name: Generate Docs
 run-name: ${{ github.actor }} is generating docs 📚
+# Runs after Semantic Release rather than alongside it. Both used to fire on the same
+# push to main, and this job's `git push` would land first — leaving semantic-release
+# behind the remote, which it treats as "don't publish" while still exiting 0. The
+# result was a green run and no release.
+#
+# The push below uses GITHUB_TOKEN, which by design does not trigger further workflow
+# runs, so chaining this way cannot loop back into Semantic Release.
 on:
-  push:
+  workflow_run:
+    workflows: ["Semantic Release Action"]
+    types: [completed]
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'typedoc.json'
+  workflow_dispatch:
 
 jobs:
   generate-docs:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,6 +27,10 @@ jobs:
           version: 10
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # workflow_run starts from the triggering run's SHA; take the tip of main so
+          # the docs commit lands on top of whatever the release just published.
+          ref: main
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,6 +1,12 @@
 name: Semantic Release Action
 run-name: ${{ github.actor }} is running Semantic Release 🚀
-on: [push]
+# Only the branches in package.json's `release.branches` can produce a release, so
+# don't run on every branch. workflow_dispatch allows re-running a release that was
+# skipped, without needing a dummy commit.
+on:
+  push:
+    branches: [main, next]
+  workflow_dispatch:
 jobs:
   Semantic-Release-Action:
     runs-on: ubuntu-latest
@@ -11,6 +17,10 @@ jobs:
           version: 10
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # semantic-release derives the last release from the tag history, so it needs
+          # all of it — not the default shallow clone.
+          fetch-depth: 0
       - name: Install dependencies (including dev dependencies)
         run: pnpm install
       - name: Semantic Release


### PR DESCRIPTION
The merge of #22 didn't produce a release. The cause is a race between two workflows, not anything in the merge itself.

## What happened

Both workflows trigger on push to `main`. They fired together at 21:45:13, and `Generate Docs` — which regenerates docs and pushes a commit — won. By the time semantic-release went to publish, `main` had moved:

```
[semantic-release] › ℹ  The local branch main is behind the remote one, therefore a new version won't be published.
```

semantic-release treats that as a routine skip and **exits 0**, so [the run](https://github.com/RevelDigital/reveldigital-client-sdk/actions/runs/29537191618) is green and nothing surfaces that the release didn't happen. That's the part worth fixing: the failure mode is invisible.

## Changes

**`generate-docs.yml` runs after the release, not alongside it.** `workflow_run` on `Semantic Release Action` completing, so it cannot push mid-release. The docs push uses `GITHUB_TOKEN`, which by design doesn't trigger workflow runs, so chaining this way can't loop back.

Two notes:
- The `paths: [src/**, typedoc.json]` filter is gone — `workflow_run` doesn't support one. Docs now regenerate after every successful release run, but the existing `git diff --staged --quiet ||` guard means nothing is committed when the output is unchanged.
- Checkout pins `ref: main`, since `workflow_run` otherwise starts from the triggering run's SHA.

**`semantic-release.yml` gains `workflow_dispatch`** so a skipped release can be re-run without a dummy commit — needed right now to release #22 — and no longer runs on every branch, only `main`/`next`, matching `release.branches` in `package.json`. It previously ran on every feature branch push and did nothing.

**Full history on checkout.** semantic-release derives the last release from the tag graph; the default shallow clone doesn't contain it. It's been getting by on its own `git fetch`, but this makes the version computation reliable rather than incidental.

Verified both files parse, and that `workflows: ["Semantic Release Action"]` matches the release workflow's `name:` exactly — a typo there fails silently.

## This alone won't release 0.6.0 — read before merging

Merging this triggers a release, so the version it picks matters.

npm's `latest` is **0.5.1**. But git carries tags `v1.0.0`, `v1.0.1`, `v1.0.1-0`, `v1.0.2-0`, `v1.0.3-0`, `v1.0.3-1` that were **never published** — no npm version, no GitHub release. They're leftovers from `changeset version` runs. semantic-release derives its baseline from the tag graph, so it currently sees `v1.0.1` and would cut **1.1.0**.

Confirmed by dry run against the real repo:

```
Analysis of 49 commits complete: minor release
The next release version is 1.1.0
```

With the six phantom tags removed (verified in a throwaway mirror):

```
Analysis of 3 commits complete: minor release
The next release version is 0.6.0
```

So the tags must be deleted **before** this merges:

```bash
git push origin --delete v1.0.0 v1.0.1 v1.0.1-0 v1.0.2-0 v1.0.3-0 v1.0.3-1
git tag -d v1.0.0 v1.0.1 v1.0.1-0 v1.0.2-0 v1.0.3-0 v1.0.3-1
```

Restore points if that's ever regretted:

```
v1.0.0    6c6774fabb35b4ae6ed19c67cd797a9fb1b5e1f9
v1.0.1    437e09bcf879d6156932f556ec8ceaa2d2c17aab
v1.0.1-0  37d78b1c4cde8c668d654dab41d1a02b317eca8d
v1.0.2-0  399a4088bb6f4590de3b3f1cb14baff41f72281b
v1.0.3-0  fc5d7972a65bb7a3fc2befce1ce136d87839d0b9
v1.0.3-1  753acf99e8ef64ff19a2e6fe5438658ba4810542
```

The `v1.0.0-alpha.*` tags stay — those map to real npm publishes.

Note `package.json` still says `1.0.1`. semantic-release ignores it and sets the version at publish time, so the published artifact will correctly say `0.6.0` (and `gen:version` runs off it via `prepublishOnly`, so `getSdkVersion()` will agree). The in-repo value is cosmetic drift, worth a separate cleanup.

## Not addressed here

The repo runs both semantic-release and changesets. 16 changesets sit unconsumed, since releases actually come from commit messages. Left alone for now, per discussion — worth its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
